### PR TITLE
Follow guideline From two-pane to single pane layout behavior.

### DIFF
--- a/app/src/main/java/com/example/sports/ui/SportsScreens.kt
+++ b/app/src/main/java/com/example/sports/ui/SportsScreens.kt
@@ -108,6 +108,7 @@ fun SportsApp(
                 selectedSport = uiState.currentSport,
                 onClick = {
                     viewModel.updateCurrentSport(it)
+                    viewModel.navigateToDetailPage()
                 },
                 onBackPressed = onBackPressed,
                 contentPadding = innerPadding,


### PR DESCRIPTION
Fix #17 
Follow guideline [From two-pane to single pane layout behavior](https://m3.material.io/foundations/layout/canonical-layouts/list-detail#19de8904-8f61-4af7-8b5a-78c9edeb62b8).
It shows detail view as move two-pane to single pane.
![Android20231217_104342](https://github.com/google-developer-training/basic-android-kotlin-compose-training-sports/assets/48680511/a1f1c91f-fb1a-4fdc-844e-d70ecb2b059e)
